### PR TITLE
feat: allow stale dns results to be returned

### DIFF
--- a/files/default/balancer.lua
+++ b/files/default/balancer.lua
@@ -31,7 +31,7 @@ local function refresh(premature)
 
     if suc then
       for service, tags in pairs(services) do
-        local sub, err = hc:request_uri("http://127.0.0.1:8500/v1/catalog/service/" .. service .. "?tag=service", {
+        local sub, err = hc:request_uri("http://127.0.0.1:8500/v1/catalog/service/" .. service .. "?tag=service&stale=1", {
           method = "GET"
         })
 


### PR DESCRIPTION
This removes pressure on the primary consul host.